### PR TITLE
Compiler 0.12 updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,13 +12,16 @@
     "url": "git://github.com/paf31/purescript-purview.git"
   },
   "dependencies": {
-    "purescript-dom-classy": "^2.2.0",
-    "purescript-incremental-functions": "^1.3.0",
-    "purescript-refs": "^3.0.0"
+    "purescript-incremental-functions": "^2.0.0",
+    "purescript-refs": "^4.1.0",
+    "purescript-web-dom": "^1.0.0",
+    "purescript-web-html": "^1.0.0",
+    "purescript-web-events": "^1.0.0",
+    "purescript-foreign-object": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0",
-    "purescript-psci-support": "^3.0.0",
-    "purescript-random": "^3.0.0"
+    "purescript-console": "^4.0.0",
+    "purescript-psci-support": "^4.0.0",
+    "purescript-random": "^4.0.0"
   }
 }

--- a/src/Purview.purs
+++ b/src/Purview.purs
@@ -5,39 +5,43 @@ module Purview
   , textWith
   , element
   , element_
+  , unsafeEventListener
   , render
-  , applyPatch
   , Component
   , run
   ) where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Ref (REF, newRef, readRef, writeRef)
-import DOM (DOM)
-import DOM.Classy.Element (appendChild, insertBefore, removeAttribute, removeChild, setAttribute, setTextContent)
-import DOM.Classy.Event.EventTarget (EventListener, addEventListener, removeEventListener)
-import DOM.Classy.Node (toNode)
-import DOM.Classy.ParentNode (children, firstElementChild)
-import DOM.HTML (window)
-import DOM.HTML.Types (htmlDocumentToDocument)
-import DOM.HTML.Window (document)
-import DOM.Node.Document (createDocumentFragment, createElement, createTextNode)
-import DOM.Node.HTMLCollection (item)
-import DOM.Node.Types (Element, Node, documentFragmentToNode, textToNode)
-import Data.Array (foldM, (!!))
-import Data.Foldable (sequence_, traverse_)
+import Data.Array ((!!))
+import Data.Foldable (foldM, sequence_, traverse_)
+import Data.FunctorWithIndex (mapWithIndex)
 import Data.Incremental (class Patch, Change, Jet, constant, fromChange, patch, toChange)
 import Data.Incremental.Array (ArrayChange(..), IArray)
 import Data.Incremental.Eq (Atomic)
 import Data.Incremental.Map (MapChange(..), MapChanges, IMap)
-import Data.Map (empty, lookup, mapWithKey)
+import Data.Map (empty, lookup)
 import Data.Maybe (Maybe(..))
 import Data.Maybe.Last (Last)
-import Data.Monoid (class Monoid, mempty)
 import Data.Newtype (unwrap, wrap)
+import Effect (Effect)
+import Effect.Ref (new, read, write) as Ref
+import Effect.Unsafe (unsafePerformEffect)
 import Partial.Unsafe (unsafeCrashWith)
+import Web.DOM.Document (createDocumentFragment, createElement, createTextNode)
+import Web.DOM.DocumentFragment as DocumentFragment
+import Web.DOM.Node (Node)
+import Web.DOM.Element (Element, removeAttribute, setAttribute)
+import Web.DOM.Element as Element
+import Web.DOM.HTMLCollection (item)
+import Web.DOM.Node as Node
+import Web.DOM.ParentNode (children, firstElementChild)
+import Web.DOM.Text as Text
+import Web.Event.Event (Event)
+import Web.Event.EventTarget (EventListener, addEventListener, eventListener, removeEventListener)
+import Web.HTML (window)
+import Web.HTML.HTMLDocument (toDocument)
+import Web.HTML.Window (document)
 
 -- | The (abstract) type of views.
 -- |
@@ -45,25 +49,25 @@ import Partial.Unsafe (unsafeCrashWith)
 -- | using the `text` and `element` functions.
 -- |
 -- | `View`s can be initially rendered to the DOM using the `render` function.
-newtype View eff = View
+newtype View = View
   { element  :: String
   , text     :: Atomic String
   , attrs    :: IMap String (Atomic String)
-  , handlers :: IMap String (Atomic (EventListener eff))
-  , kids     :: IArray (View eff)
+  , handlers :: IMap String (Atomic EventListener)
+  , kids     :: IArray View
   }
 
 -- | The (abstract) type of view updates.
 -- |
 -- | `View`s can be applied to the DOM using the `applyPatch` function.
-newtype ViewChanges eff = ViewChanges
+newtype ViewChanges = ViewChanges
   { text     :: Last String
   , attrs    :: MapChanges String (Atomic String) (Last String)
-  , handlers :: MapChanges String (Atomic (EventListener eff)) (Last (EventListener eff))
-  , kids     :: Array (ArrayChange (View eff) (ViewChanges eff))
+  , handlers :: MapChanges String (Atomic EventListener) (Last EventListener)
+  , kids     :: Array (ArrayChange View ViewChanges)
   }
 
-instance semigroupViewChanges :: Semigroup (ViewChanges eff) where
+instance semigroupViewChanges :: Semigroup ViewChanges where
   append (ViewChanges a) (ViewChanges b) =
     ViewChanges
       { text:     a.text     <> b.text
@@ -72,10 +76,10 @@ instance semigroupViewChanges :: Semigroup (ViewChanges eff) where
       , kids:     a.kids     <> b.kids
       }
 
-instance monoidViewChanges :: Monoid (ViewChanges eff) where
+instance monoidViewChanges :: Monoid ViewChanges where
   mempty = ViewChanges { text: mempty, attrs: mempty, handlers: mempty, kids: mempty }
 
-instance patchView :: Patch (View eff) (ViewChanges eff) where
+instance patchView :: Patch View ViewChanges where
   patch (View v) (ViewChanges vc) =
     View v { text     = patch v.text     vc.text
            , attrs    = patch v.attrs    vc.attrs
@@ -83,14 +87,25 @@ instance patchView :: Patch (View eff) (ViewChanges eff) where
            , kids     = patch v.kids     vc.kids
            }
 
+-- | Create an `EventListener` unsafely.
+-- |
+-- | This operation is unsafe in the sense that applying it multiple times
+-- | to the same argument will result in event listeners which are not
+-- | substitutable in all contexts.
+-- |
+-- | However, for the purposes of the current API, it's very useful to be
+-- | able to create `EventListener`s unsafely in this way, and then store
+-- | the results in a `View`.
+unsafeEventListener :: (Event -> Effect Unit) -> EventListener
+unsafeEventListener = unsafePerformEffect <<< eventListener
+
 view_
-  :: forall eff
-   . String
+  :: String
   -> Jet (Atomic String)
   -> Jet (IMap String (Atomic String))
-  -> Jet (IMap String (Atomic (EventListener eff)))
-  -> Jet (IArray (View eff))
-  -> Jet (View eff)
+  -> Jet (IMap String (Atomic EventListener))
+  -> Jet (IArray View)
+  -> Jet View
 view_ elName text_ attrs handlers kids =
   { position: View
       { element: elName
@@ -108,30 +123,28 @@ view_ elName text_ attrs handlers kids =
   }
 
 -- | Create a text node wrapped in an element with the specified name.
-textWith :: forall eff. String -> Jet (Atomic String) -> Jet (View eff)
+textWith :: String -> Jet (Atomic String) -> Jet View
 textWith elName s = view_ elName s (constant (wrap empty)) (constant (wrap empty)) (constant (wrap []))
 
 -- | Create a text node wrapped in a `<span>` element.
-text :: forall eff. Jet (Atomic String) -> Jet (View eff)
+text :: Jet (Atomic String) -> Jet View
 text = textWith "span"
 
 -- | Create an element with the given name, attributes, event listeners and
 -- | children.
 element
-  :: forall eff
-   . String
+  :: String
   -> Jet (IMap String (Atomic String))
-  -> Jet (IMap String (Atomic (EventListener eff)))
-  -> Jet (IArray (View eff))
-  -> Jet (View eff)
+  -> Jet (IMap String (Atomic EventListener))
+  -> Jet (IArray View)
+  -> Jet View
 element elName = view_ elName (constant (wrap ""))
 
 -- | Create an element with no attributes or event handlers.
 element_
-  :: forall eff
-   . String
-  -> Jet (IArray (View eff))
-  -> Jet (View eff)
+  :: String
+  -> Jet (IArray View)
+  -> Jet View
 element_ elName kids = view_ elName (constant (wrap "")) (constant (wrap empty)) (constant (wrap empty)) kids
 
 -- | Render a `View` to the DOM, under the given `Node`, and connect any
@@ -139,20 +152,16 @@ element_ elName kids = view_ elName (constant (wrap "")) (constant (wrap empty))
 -- |
 -- | Once the initial `View` is rendered, the DOM can be updated using the
 -- | `applyPatch` function.
-render
-  :: forall eff
-   . Node
-  -> View (dom :: DOM | eff)
-  -> Eff (dom :: DOM | eff) Unit
+render :: Node -> View -> Effect Unit
 render n (View v) = do
-  doc <- window >>= document >>> map htmlDocumentToDocument
+  doc <- window >>= document >>> map toDocument
   ne <- createElement v.element doc
   tn <- createTextNode (unwrap v.text) doc
-  _ <- appendChild (textToNode tn) ne
-  sequence_ (mapWithKey (\k s -> setAttribute k (unwrap s) ne) (unwrap v.attrs))
-  sequence_ (mapWithKey (\k h -> addEventListener (wrap k) (unwrap h) false ne) (unwrap v.handlers))
-  traverse_ (render (toNode ne)) (unwrap v.kids)
-  _ <- appendChild ne n
+  _ <- Node.appendChild (Text.toNode tn) (Element.toNode ne)
+  sequence_ (mapWithIndex (\k s -> setAttribute k (unwrap s) ne) (unwrap v.attrs))
+  sequence_ (mapWithIndex (\k h -> addEventListener (wrap k) (unwrap h) false (Element.toEventTarget ne)) (unwrap v.handlers))
+  traverse_ (render (Element.toNode ne)) (unwrap v.kids)
+  _ <- Node.appendChild (Element.toNode ne) n
   pure unit
 
 -- | Apply a set of `ViewChanges` to the DOM, under the given `Node`, which should
@@ -167,63 +176,58 @@ render n (View v) = do
 -- | obtained using the `patch` function.
 -- |
 -- | See the implementation of the `run` function for an example.
-applyPatch
-  :: forall eff
-   . Element
-  -> View (dom :: DOM | eff)
-  -> ViewChanges (dom :: DOM | eff)
-  -> Eff (dom :: DOM | eff) Unit
+applyPatch :: Element -> View -> ViewChanges -> Effect Unit
 applyPatch e vv@(View v) (ViewChanges vc) = do
-    _ <- traverse_ (_ `setTextContent` e) vc.text
-    sequence_ (mapWithKey updateAttr (unwrap vc.attrs))
-    sequence_ (mapWithKey updateHandler (unwrap vc.handlers))
+    _ <- traverse_ (_ `Node.setTextContent` Element.toNode e) vc.text
+    sequence_ (mapWithIndex updateAttr (unwrap vc.attrs))
+    sequence_ (mapWithIndex updateHandler (unwrap vc.handlers))
     void $ foldM updateChildren v.kids vc.kids
   where
     updateAttr
       :: String
       -> MapChange (Atomic String) (Last String)
-      -> Eff (dom :: DOM | eff) Unit
+      -> Effect Unit
     updateAttr k (Add val) = setAttribute k (unwrap val) e
     updateAttr k Remove = removeAttribute k e
     updateAttr k (Update u) = traverse_ (\s -> setAttribute k s e) (unwrap u)
 
     updateHandler
       :: String
-      -> MapChange (Atomic (EventListener (dom :: DOM | eff))) (Last (EventListener (dom :: DOM | eff)))
-      -> Eff (dom :: DOM | eff) Unit
+      -> MapChange (Atomic EventListener) (Last EventListener)
+      -> Effect Unit
     updateHandler k (Add h) = do
-      addEventListener (wrap k) (unwrap h) false e
+      addEventListener (wrap k) (unwrap h) false (Element.toEventTarget e)
     updateHandler k Remove = do
       lookup k (unwrap v.handlers) # traverse_ \h ->
-        removeEventListener (wrap k) (unwrap h) false e
+        removeEventListener (wrap k) (unwrap h) false (Element.toEventTarget e)
     updateHandler k (Update dh) = dh # traverse_ \new -> do
       lookup k (unwrap v.handlers) # traverse_ \old ->
-        removeEventListener (wrap k) (unwrap old) false e
-      addEventListener (wrap k) new false e
+        removeEventListener (wrap k) (unwrap old) false (Element.toEventTarget e)
+      addEventListener (wrap k) new false (Element.toEventTarget e)
 
     updateChildren
-      :: IArray (View (dom :: DOM | eff))
-      -> ArrayChange (View (dom :: DOM | eff)) (ViewChanges (dom :: DOM | eff))
-      -> Eff (dom :: DOM | eff) (IArray (View (dom :: DOM | eff)))
+      :: IArray View
+      -> ArrayChange View ViewChanges
+      -> Effect (IArray View)
     updateChildren kids ch@(InsertAt i vw) = do
-      doc <- window >>= document >>> map htmlDocumentToDocument
-      cs <- children e
+      doc <- window >>= document >>> map toDocument
+      cs <- children (Element.toParentNode e)
       mc <- item i cs
-      newNode <- documentFragmentToNode <$> createDocumentFragment doc
+      newNode <- DocumentFragment.toNode <$> createDocumentFragment doc
       render newNode vw
       _ <- case mc of
-        Just c -> insertBefore newNode c e
-        Nothing -> appendChild newNode e
+        Just c -> Node.insertBefore newNode (Element.toNode c) (Element.toNode e)
+        Nothing -> Node.appendChild newNode (Element.toNode e)
       pure (patch kids [ch])
     updateChildren kids ch@(DeleteAt i) = do
-      cs <- children e
+      cs <- children (Element.toParentNode e)
       mc <- item i cs
       case mc of
-        Just c -> void (removeChild c e)
+        Just c -> void (Node.removeChild (Element.toNode c) (Element.toNode e))
         Nothing -> pure unit
       pure (patch kids [ch])
     updateChildren kids ch@(ModifyAt i dv) = do
-      cs <- children e
+      cs <- children (Element.toParentNode e)
       mc <- item i cs
       mc # traverse_ \c ->
         unwrap kids !! i # traverse_ \cv ->
@@ -235,10 +239,10 @@ applyPatch e vv@(View v) (ViewChanges vc) = do
 -- | A component takes a changing update function, and a changing `model`
 -- | and returns a changing `View`. The update function receives a `Change` to
 -- | the model and applies it.
-type Component model eff
-   = Jet (Atomic (Change model -> Eff eff Unit))
+type Component model
+   = Jet (Atomic (Change model -> Effect Unit))
   -> Jet model
-  -> Jet (View eff)
+  -> Jet View
 
 -- | An example implementation of an application loop.
 -- |
@@ -246,20 +250,20 @@ type Component model eff
 -- | on the current value of the `model`, which can change over time by the
 -- | application of `Change`s in event handlers.
 run
-  :: forall model change eff
+  :: forall model change
    . Patch model change
   => Element
-  -> Component model (dom :: DOM, ref :: REF | eff)
+  -> Component model
   -> model
-  -> Eff (dom :: DOM, ref :: REF | eff) Unit
+  -> Effect Unit
 run root component initialModel = do
-  modelRef <- newRef initialModel
-  viewRef <- newRef Nothing
+  modelRef <- Ref.new initialModel
+  viewRef <- Ref.new Nothing
   document <- window >>= document
   let initialView = (component (constant (wrap onChange)) (constant initialModel)).position
       onChange modelChange = do
-        currentModel <- readRef modelRef
-        currentView_ <- readRef viewRef
+        currentModel <- Ref.read modelRef
+        currentView_ <- Ref.read viewRef
         case currentView_ of
           Nothing -> unsafeCrashWith "viewRef was empty"
           Just currentView -> do
@@ -269,10 +273,10 @@ run root component initialModel = do
                 -- to apply. This way, we can use the stored view to detach event
                 -- handlers correctly later, if necessary.
                 newView = patch currentView patches
-            writeRef modelRef newModel
-            writeRef viewRef (Just newView)
-            firstElementChild root >>= traverse_ \e ->
+            Ref.write newModel modelRef
+            Ref.write (Just newView) viewRef
+            firstElementChild (Element.toParentNode root) >>= traverse_ \e ->
               applyPatch e currentView patches
       updater m dm = fromChange (component (constant (wrap onChange)) { position: m, velocity: dm }).velocity
-  writeRef viewRef (Just initialView)
-  render (toNode root) initialView
+  Ref.write (Just initialView) viewRef
+  render (Element.toNode root) initialView

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,15 +2,8 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, log)
-import Control.Monad.Eff.Ref (REF)
-import DOM (DOM)
-import DOM.Event.EventTarget (eventListener)
-import DOM.HTML (window)
-import DOM.HTML.Types (htmlDocumentToNonElementParentNode)
-import DOM.HTML.Window (document)
-import DOM.Node.NonElementParentNode (getElementById)
+import Effect (Effect)
+import Effect.Console (log)
 import Data.Incremental (class Patch, constant)
 import Data.Incremental.Array (IArray)
 import Data.Incremental.Array as IArray
@@ -18,13 +11,16 @@ import Data.Incremental.Eq (Atomic)
 import Data.Incremental.Eq as Atomic
 import Data.Incremental.Map as IMap
 import Data.Maybe (Maybe(..))
-import Data.Monoid (mempty)
 import Data.Newtype (wrap)
-import Purview (Component, element, element_, run, text)
+import Purview (Component, element, element_, run, text, unsafeEventListener)
+import Web.DOM.NonElementParentNode (getElementById)
+import Web.HTML (window)
+import Web.HTML.HTMLDocument (toNonElementParentNode)
+import Web.HTML.Window (document)
 
 type Counter = Atomic Int
 
-counter :: forall eff. Component Counter eff
+counter :: Component Counter
 counter change model =
     element "button" (constant (wrap mempty))
       -- ^ a <button> with no attributes
@@ -32,17 +28,17 @@ counter change model =
       -- ^ onclick handler
       (IArray.singleton (text (Atomic.map (("Current value = " <> _) <<< show) model)))
   where
-    onClick f current = eventListener \_ ->
+    onClick f current = unsafeEventListener \_ ->
       f (Atomic.replace (current + 1))
 
 listOf
-  :: forall model change eff
+  :: forall model change
    . Patch model change
   => model
-  -> Component model eff
-  -> Component (IArray model) eff
+  -> Component model
+  -> Component (IArray model)
 listOf dflt component change xs =
-  let addCounter = Atomic.map (\change_ -> eventListener \_ ->
+  let addCounter = Atomic.map (\change_ -> unsafeEventListener \_ ->
         change_ (IArray.insertAt 0 dflt)) change
    in element_ "div" $ IArray.static
         [ element "button" (constant (wrap mempty))
@@ -51,7 +47,7 @@ listOf dflt component change xs =
         , element_ "ol" $
             IArray.mapWithIndex (\i x ->
               let changeAt i_ change_ c = change_ (IArray.modifyAt i_ c)
-                  delete = Atomic.lift2 (\i_ change_ -> eventListener \_ ->
+                  delete = Atomic.lift2 (\i_ change_ -> unsafeEventListener \_ ->
                     change_ (IArray.deleteAt i_)) i change
                in element_ "li" $ IArray.static
                     [ component (Atomic.lift2 changeAt i change) x
@@ -62,10 +58,10 @@ listOf dflt component change xs =
                   ) xs
         ]
 
-main :: Eff (dom :: DOM, console :: CONSOLE, ref :: REF) Unit
+main :: Effect Unit
 main = do
-  document <- map htmlDocumentToNonElementParentNode (window >>= document)
-  container <- getElementById (wrap "container") document
+  document <- map toNonElementParentNode (window >>= document)
+  container <- getElementById "container" document
   case container of
     Just el -> run el (listOf (wrap 0) counter) (wrap [])
     Nothing -> log "No 'container' node!"


### PR DESCRIPTION
An alternative set of updates for 0.12, which keep the current simpler internal approach, at the expense of requiring the user to continue creating event handlers unsafely.